### PR TITLE
Fix getCommitInfo to get the hunk even with EOL changed case.

### DIFF
--- a/commenter/commenter.go
+++ b/commenter/commenter.go
@@ -3,9 +3,10 @@ package commenter
 import (
 	"errors"
 	"fmt"
-	"github.com/google/go-github/v32/github"
 	"regexp"
 	"strconv"
+
+	"github.com/google/go-github/v32/github"
 )
 
 // Commenter is the main commenter struct
@@ -163,11 +164,17 @@ func buildComment(file, comment string, line int, info commitFileInfo) *github.P
 func getCommitInfo(file *github.CommitFile) (*commitFileInfo, error) {
 
 	groups := patchRegex.FindAllStringSubmatch(file.GetPatch(), -1)
+	var hunkStart, hunkEnd int
 	if len(groups) < 1 {
-		return nil, errors.New("the patch details could not be resolved")
+		if file.GetChanges() >= 1 {
+			hunkStart, hunkEnd = 1, 1
+		} else {
+			return nil, errors.New("the patch details could not be resolved")
+		}
+	} else {
+		hunkStart, _ = strconv.Atoi(groups[0][1])
+		hunkEnd, _ = strconv.Atoi(groups[0][2])
 	}
-	hunkStart, _ := strconv.Atoi(groups[0][1])
-	hunkEnd, _ := strconv.Atoi(groups[0][2])
 
 	shaGroups := commitRefRegex.FindAllStringSubmatch(file.GetContentsURL(), -1)
 	if len(shaGroups) < 1 {


### PR DESCRIPTION
Hi,
This tool is very nice. However, I encountered a situation where it did not work well in my case.
Example :
- Changing EOL only
- New file with only one line of code

In this modification, I fixed it to work well in the above cases.
It may not be a good fix as it is quite hard coded.