### PR TITLE
fix `parseHunkPositions` to parse second part as hunk length instead of hunk end line

### DIFF
--- a/commenter/commitFileInfo.go
+++ b/commenter/commitFileInfo.go
@@ -18,7 +18,7 @@ type hunkInfo struct {
 }
 
 func (hi hunkInfo) isLineInHunk(line int) bool {
-	return line >= hi.hunkStart && line <= hi.hunkEnd
+	return line >= hi.hunkStart && line <= hi.hunkStart + hi.hunkEnd
 }
 
 func getCommitFileInfo(ghConnector *connector) ([]*commitFileInfo, error) {


### PR DESCRIPTION
Fix parsing hunk position to parse as length instead of hunk end line

Closes #18